### PR TITLE
Fixed an unhandled exception bug [765]

### DIFF
--- a/GenericTableAPI/NoAuthenticationHandler.cs
+++ b/GenericTableAPI/NoAuthenticationHandler.cs
@@ -1,0 +1,26 @@
+﻿using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+
+namespace GenericTableAPI;
+
+public class NoAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public NoAuthenticationHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger, UrlEncoder encoder)
+        : base(options, logger, encoder)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var claims = new List<Claim>();
+        var identity = new ClaimsIdentity(claims, Scheme.Name);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, Scheme.Name);
+
+        var result = AuthenticateResult.Success(ticket);
+
+        return Task.FromResult(result);
+    }
+}

--- a/GenericTableAPI/Program.cs
+++ b/GenericTableAPI/Program.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.Filters;
 using Serilog;
@@ -79,7 +78,6 @@ namespace GenericTableAPI
             // Authentication Configuration
             string? jwtKey = builder.Configuration["JwtSettings:Key"];
             string? basicAuthUser = builder.Configuration["BasicAuthSettings:Username"];
-            bool isAuthenticationConfigured = false;
 
             if (!string.IsNullOrEmpty(jwtKey))
             {
@@ -94,13 +92,16 @@ namespace GenericTableAPI
                             ValidateAudience = false
                         };
                     });
-                isAuthenticationConfigured = true;
             }
             else if (!string.IsNullOrEmpty(basicAuthUser))
             {
                 builder.Services.AddAuthentication("BasicAuthentication")
                     .AddScheme<AuthenticationSchemeOptions, BasicAuthenticationHandler>("BasicAuthentication", null);
-                isAuthenticationConfigured = true;
+            }
+            else
+            {
+                builder.Services.AddAuthentication("NoAuthentication")
+                    .AddScheme<AuthenticationSchemeOptions, NoAuthenticationHandler>("NoAuthentication", null);
             }
             
             builder.Services.AddAuthorization(options =>
@@ -108,15 +109,7 @@ namespace GenericTableAPI
                 // Define a custom policy that allows authenticated or anonymous access based on configuration
                 options.AddPolicy("DynamicAuthentication", policyBuilder =>
                 {
-                    policyBuilder.RequireAssertion(context =>
-                    {
-                        // Logic to determine if authentication should be enforced
-                        if (!isAuthenticationConfigured)
-                        {
-                            return true; // Always succeed authorization
-                        }
-                        return context.User.Identity.IsAuthenticated; // Check if the user is authenticated
-                    });
+                    policyBuilder.RequireAssertion(context => context.User.Identity.IsAuthenticated);
                 });
             });
             
@@ -132,10 +125,7 @@ namespace GenericTableAPI
 
             app.UseHttpsRedirection();
             
-            if (isAuthenticationConfigured)
-            {
-                app.UseAuthentication();
-            }
+            app.UseAuthentication();
             app.UseAuthorization();
             
             // prioritize controllers in the following order


### PR DESCRIPTION
Trying to access a table that was not specified in tablesettings without any authorization options in appsettings was causing an Unhandled exception to show up for the end user. This fix adds a fallback when no authentication is set that always results in success.